### PR TITLE
warn on connection failure

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -48,11 +48,18 @@ $(document).ready(function() {
             console.log("Account data", accountData);
 
             // Update address in case it's not defined yet
-            if (!address && accountData.addresses[0]) {
+            try{
+                if (!address && accountData.addresses[0]) {
 
                 address = iota.utils.addChecksum(accountData.addresses[accountData.addresses.length - 1]);
 
-                updateAddressHTML(address);
+                    updateAddressHTML(address);
+                }
+            } catch(e) {
+
+                    var html = '<div class="alert alert-danger" align="center">Something went wrong. Make sure your local IRI is running on port 14265</div>';
+                    $("#enterSeed").html(html);
+                    return;
             }
 
             var transferList = [];


### PR DESCRIPTION
Hey,

This is a pull request and issue at the same time. I'm running the latest IRI version as follows:
```
java -jar iri-1.4.1.2.jar  -p 14265
```
on java
```
openjdk version "1.8.0_144"
```
Unfortunately, the chrome debugger reports the following when entering and submitting the seed:
```
localhost:14265/ Failed to load resource: net::ERR_CONNECTION_REFUSED
index.js:48 Account data undefined
```
At first I forgot to run the IRI and thought it would be nice to have a more self-explanatory error message like it's implemented in this PR:

![screenshot from 2017-12-01 10-47-51](https://user-images.githubusercontent.com/1038455/33477198-1dd3871a-d685-11e7-8ba2-9a998f9f15e6.png)

However, the problem occurs also when IRI is running. The pyota examples fail as well with response: invalid API version. So, I guess I oversaw something obvious here.
